### PR TITLE
BaSP-MR-120: trainer email validation fixed

### DIFF
--- a/src/Validations/trainer.js
+++ b/src/Validations/trainer.js
@@ -45,7 +45,7 @@ const trainerSchema = Joi.object({
     })
     .required(),
   email: Joi.string()
-    .pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)
+    .pattern(/^[a-zA-Z0-9._%+-]+@[a-zA-Z.-]+(?!\d)\.[a-zA-Z]{2,}$/)
     .required()
     .messages({
       'string.pattern.base': 'This input should be a valid email',


### PR DESCRIPTION
Trainer email validation shouldn't accept numbers after '@'.