### PR TITLE
BaSP-MR-219: Hotfix on superAdmin profile

### DIFF
--- a/src/Components/Layout/Header/index.jsx
+++ b/src/Components/Layout/Header/index.jsx
@@ -46,7 +46,11 @@ function Header(props) {
             <>
               <Link
                 className={styles.profileLink}
-                to={`/user/${role.toLowerCase()}/profile/${userLogged?._id}`}
+                to={
+                  role === 'SUPER_ADMIN'
+                    ? `/user/super-admin/profile/${userLogged?._id}`
+                    : `/user/${role.toLowerCase()}/profile/${userLogged?._id}`
+                }
               >
                 <div className={styles.profileContainer}>
                   <img


### PR DESCRIPTION
Development to respond [Trello-MR#219](https://trello.com/c/J1QPKNmo)

### Fix
- There was the problem when the superadmin wanted to see his profile, the redirect was not working because the route name was not parsing correctly. Now there is a conditional operator to handle it.