### PR TITLE
Hotfix-MR-221: fixing first render, login was not recognized

### DIFF
--- a/src/Components/Landing/Landing.jsx
+++ b/src/Components/Landing/Landing.jsx
@@ -121,10 +121,10 @@ function Landing() {
                 <FontAwesomeIcon
                   icon={faCloud}
                   style={{ color: '#6d15e8', alignSelf: 'center' }}
-                  size="l"
+                  size="lg"
                 />
                 <FontAwesomeIcon icon={faUserAstronaut} style={{ color: '#373867' }} size="2xl" />
-                <FontAwesomeIcon icon={faStar} style={{ color: '#dedeef93' }} size="l" />
+                <FontAwesomeIcon icon={faStar} style={{ color: '#dedeef93' }} size="lg" />
               </div>
 
               <h3>Classic</h3>
@@ -146,12 +146,12 @@ function Landing() {
             </div>
             <div className={styles.membershipCard}>
               <div className={styles.tier}>
-                <FontAwesomeIcon icon={faCloud} style={{ color: '#6d15e8' }} size="l" />
+                <FontAwesomeIcon icon={faCloud} style={{ color: '#6d15e8' }} size="lg" />
                 <FontAwesomeIcon icon={faUserAstronaut} style={{ color: '#373867' }} size="2xl" />
                 <FontAwesomeIcon
                   icon={faStar}
                   style={{ color: '#e8b315', alignSelf: 'flex-end' }}
-                  size="l"
+                  size="lg"
                 />
               </div>
               <h3>Black</h3>

--- a/src/Components/Layout/Header/index.jsx
+++ b/src/Components/Layout/Header/index.jsx
@@ -15,12 +15,12 @@ function Header(props) {
   const history = useHistory();
 
   const role = sessionStorage.getItem('role');
-  const userLogged = useSelector((state) => state.auth.user);
+  const { user: userLogged } = useSelector((state) => state.auth);
 
   const { show, message, state } = useSelector((state) => state.toast);
 
-  const handleLogout = async () => {
-    await dispatch(logOut());
+  const handleLogout = () => {
+    dispatch(logOut());
     history.push('/');
     dispatch(handleDisplayToast(true));
     dispatch(setContentToast({ message: 'See you later', state: 'success' }));
@@ -42,7 +42,7 @@ function Header(props) {
           />
         </div>
         <div className={styles.container2}>
-          {role && (
+          {role && userLogged && (
             <>
               <Link
                 className={styles.profileLink}

--- a/src/Components/Layout/Header/index.jsx
+++ b/src/Components/Layout/Header/index.jsx
@@ -19,8 +19,8 @@ function Header(props) {
 
   const { show, message, state } = useSelector((state) => state.toast);
 
-  const handleLogout = () => {
-    dispatch(logOut());
+  const handleLogout = async () => {
+    await dispatch(logOut());
     history.push('/');
     dispatch(handleDisplayToast(true));
     dispatch(setContentToast({ message: 'See you later', state: 'success' }));

--- a/src/Components/Layout/Home/index.jsx
+++ b/src/Components/Layout/Home/index.jsx
@@ -18,7 +18,7 @@ function Home() {
   return (
     <>
       <section className={styles.container}>
-        {!role && (
+        {!role && !sessionStorage.getItem('role') && (
           <div className={styles.buttonContainer} data-testid="home-buttons-container">
             <Button
               text="Sign Up"

--- a/src/Components/Layout/Home/index.jsx
+++ b/src/Components/Layout/Home/index.jsx
@@ -12,13 +12,12 @@ import ResponseModal from 'Components/Shared/ResponseModal';
 function Home() {
   const dispatch = useDispatch();
   const history = useHistory();
-  const role = sessionStorage.getItem('role');
   const { show, message, state } = useSelector((state) => state.toast);
 
   return (
     <>
       <section className={styles.container}>
-        {!role && !sessionStorage.getItem('role') && (
+        {!sessionStorage.getItem('role') && (
           <div className={styles.buttonContainer} data-testid="home-buttons-container">
             <Button
               text="Sign Up"

--- a/src/Components/Shared/Schedule/index.jsx
+++ b/src/Components/Shared/Schedule/index.jsx
@@ -205,20 +205,22 @@ const Schedule = () => {
         >
           {modalData.subId ? (
             <>
-              {`Activity: ${modalData.activityName}`}
+              {`Activity: ${modalData?.activityName}`}
               <br />
               {`Description: ${modalData.desc}`}
               <br />
             </>
           ) : (
             <>
-              {`Activity: ${modalData.activity.name}`}
+              {`Activity: ${modalData.activity?.name}`}
               <br />
-              {`Description: ${modalData.activity.description}`}
+              {`Description: ${modalData.activity?.description}`}
               <br />
             </>
           )}
-          {`Trainer: ${modalData.trainer.firstName} ${modalData.trainer.lastName}`}
+          {modalData.trainer
+            ? `Trainer: ${modalData.trainer?.firstName} ${modalData.trainer?.lastName}`
+            : 'There are not trainers for this class'}
           <br />
           {`Remaining slots: ${modalData.capacity}`}
           <br />

--- a/src/Components/SuperAdmins/Profile/index.jsx
+++ b/src/Components/SuperAdmins/Profile/index.jsx
@@ -4,7 +4,7 @@ import styles from 'Components/Admins/Profile/profile.module.css';
 
 function SuperAdminProfile() {
   const superAdmin = useSelector((state) => state.auth.user || '');
-  console.log(superAdmin);
+
   return (
     <>
       <div className={styles.form}>

--- a/src/Components/SuperAdmins/Profile/index.jsx
+++ b/src/Components/SuperAdmins/Profile/index.jsx
@@ -4,6 +4,7 @@ import styles from 'Components/Admins/Profile/profile.module.css';
 
 function SuperAdminProfile() {
   const superAdmin = useSelector((state) => state.auth.user || '');
+  console.log(superAdmin);
   return (
     <>
       <div className={styles.form}>

--- a/src/Components/helper/firebase/index.js
+++ b/src/Components/helper/firebase/index.js
@@ -14,6 +14,7 @@ export const firebaseApp = firebase.initializeApp(firebaseConfig);
 
 export const tokenListener = (resolve) => {
   firebase.auth().onIdTokenChanged(async (user) => {
+    console.log(user);
     if (user) {
       const token = await user.getIdToken();
       const {
@@ -21,7 +22,11 @@ export const tokenListener = (resolve) => {
       } = await user.getIdTokenResult();
       sessionStorage.setItem('role', role);
       sessionStorage.setItem('token', token);
+    } else {
+      sessionStorage.removeItem('token', '');
+      sessionStorage.removeItem('role', '');
     }
+
     if (resolve) {
       resolve();
     }

--- a/src/Components/helper/firebase/index.js
+++ b/src/Components/helper/firebase/index.js
@@ -14,7 +14,6 @@ export const firebaseApp = firebase.initializeApp(firebaseConfig);
 
 export const tokenListener = (resolve) => {
   firebase.auth().onIdTokenChanged(async (user) => {
-    console.log(user);
     if (user) {
       const token = await user.getIdToken();
       const {

--- a/src/Components/helper/firebase/index.js
+++ b/src/Components/helper/firebase/index.js
@@ -25,9 +25,6 @@ export const tokenListener = (resolve) => {
       sessionStorage.removeItem('token', '');
       sessionStorage.removeItem('role', '');
     }
-
-    if (resolve) {
-      resolve();
-    }
+    resolve();
   });
 };

--- a/src/Components/helper/firebase/index.js
+++ b/src/Components/helper/firebase/index.js
@@ -12,7 +12,7 @@ const firebaseConfig = {
 
 export const firebaseApp = firebase.initializeApp(firebaseConfig);
 
-export const tokenListener = () => {
+export const tokenListener = (resolve) => {
   firebase.auth().onIdTokenChanged(async (user) => {
     if (user) {
       const token = await user.getIdToken();
@@ -21,6 +21,9 @@ export const tokenListener = () => {
       } = await user.getIdTokenResult();
       sessionStorage.setItem('role', role);
       sessionStorage.setItem('token', token);
+    }
+    if (resolve) {
+      resolve();
     }
   });
 };

--- a/src/Redux/Auth/thunks.js
+++ b/src/Redux/Auth/thunks.js
@@ -73,7 +73,6 @@ export const logOut = () => {
       sessionStorage.removeItem('role', '');
       return { error: false, message: 'Log Out Successfully' };
     } catch (error) {
-      console.error(error);
       dispatch(logoutError(error));
       return {
         error: true,

--- a/src/Routes/admins/index.jsx
+++ b/src/Routes/admins/index.jsx
@@ -43,6 +43,7 @@ const routes = [
 
 const AdminRoutes = () => {
   const { url } = useRouteMatch();
+
   return (
     <Layout routes={routes}>
       <Switch>

--- a/src/Routes/index.jsx
+++ b/src/Routes/index.jsx
@@ -1,6 +1,5 @@
 import React, { lazy, Suspense, useEffect, useState } from 'react';
 import { Switch, Route, Redirect, useHistory } from 'react-router-dom';
-import { setContentToast, handleDisplayToast } from 'Redux/Shared/ResponseToast/actions';
 import { useDispatch } from 'react-redux';
 
 import { getAuth } from 'Redux/Auth/thunks';
@@ -23,21 +22,16 @@ const Routes = () => {
 
   useEffect(() => {
     const setupTokenListener = async () => {
-      try {
-        await new Promise((resolve) => {
-          tokenListener(resolve);
-        });
+      await new Promise((resolve) => {
+        tokenListener(resolve);
+      });
 
-        const token = sessionStorage.getItem('token');
-        const role = sessionStorage.getItem('role');
-        setUser({ token, role });
+      const token = sessionStorage.getItem('token');
+      const role = sessionStorage.getItem('role');
+      setUser({ token, role });
 
-        if (token) {
-          dispatch(getAuth(token));
-        }
-      } catch (error) {
-        dispatch(setContentToast({ message: error.toString(), state: 'fail' }));
-        dispatch(handleDisplayToast(true));
+      if (token) {
+        dispatch(getAuth(token));
       }
     };
 

--- a/src/Routes/index.jsx
+++ b/src/Routes/index.jsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense, useEffect, useState } from 'react';
-import { Switch, Route, Redirect, useHistory } from 'react-router-dom';
+import { Switch, Route, Redirect, useHistory, useLocation } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
 import { getAuth } from 'Redux/Auth/thunks';
@@ -18,7 +18,9 @@ const TrainerRoutes = lazy(() => import('./trainers'));
 const Routes = () => {
   const dispatch = useDispatch();
   const [user, setUser] = useState();
+  const [path, setPath] = useState();
   const history = useHistory();
+  const location = useLocation();
 
   useEffect(() => {
     const setupTokenListener = async () => {
@@ -29,6 +31,7 @@ const Routes = () => {
       const token = sessionStorage.getItem('token');
       const role = sessionStorage.getItem('role');
       setUser({ token, role });
+      setPath(location.pathname);
 
       if (token) {
         dispatch(getAuth(token));
@@ -39,17 +42,20 @@ const Routes = () => {
   }, [dispatch]);
 
   useEffect(() => {
-    const paths = {
-      SUPER_ADMIN: '/user/super-admin',
-      ADMIN: '/user/admin',
-      TRAINER: '/user/trainer',
-      MEMBER: '/user/member'
-    };
-
-    if (user?.role && paths[user?.role]) {
-      history.push(paths[user.role]);
+    if (path === '/') {
+      const paths = {
+        SUPER_ADMIN: '/user/super-admin',
+        ADMIN: '/user/admin',
+        TRAINER: '/user/trainer',
+        MEMBER: '/user/member'
+      };
+      if (user?.role && paths[user?.role]) {
+        history.push(paths[user.role]);
+      }
+    } else {
+      history.push(path);
     }
-  }, [user?.token, history]);
+  }, [user?.token, path]);
 
   return (
     <Suspense

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Routes from './Routes/index';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 
 import { Provider } from 'react-redux';
@@ -9,7 +10,9 @@ import { store } from './Redux/store';
 ReactDOM.render(
   <Provider store={store}>
     <React.StrictMode>
-      <Routes />
+      <BrowserRouter>
+        <Routes />
+      </BrowserRouter>
     </React.StrictMode>
   </Provider>,
   document.getElementById('root')


### PR DESCRIPTION
A bug was fixed where the user login was not recognized in the first page render.

Before: When opening another tab, neither the token nor the role were correctly loaded due to being asynchronous, so the app required a new login (or reloading the page).
![image](https://github.com/BaSP-m2023/baru-megarocket-app/assets/99512277/249e9eee-812c-4ae3-86fe-6f93dca269ea)

Now: With these changes, the role and token are correctly setted even if its the first render of the page, now the user is logged in until a logout occurs.
