### PR TITLE
BaSP-MR-227: Create, delete and edit trainer from admin resource fixed

### DIFF
--- a/src/Components/Layout/Header/index.jsx
+++ b/src/Components/Layout/Header/index.jsx
@@ -26,8 +26,6 @@ function Header(props) {
     dispatch(setContentToast({ message: 'See you later', state: 'success' }));
   };
 
-  console.log(role);
-
   return (
     <header>
       <div className={styles.container}>

--- a/src/Redux/Trainers/reducers.js
+++ b/src/Redux/Trainers/reducers.js
@@ -53,7 +53,8 @@ const trainersReducer = (state = INITIAL_STATE, action) => {
         ...state,
         isPending: false,
         data: [...state.data, action.payload],
-        error: null
+        error: null,
+        redirect: true
       };
     case ADD_TRAINER_ERROR:
       return {

--- a/src/Redux/Trainers/thunks.js
+++ b/src/Redux/Trainers/thunks.js
@@ -32,20 +32,21 @@ export const getTrainers = () => {
       const { data, message, error } = await response.json();
       if (!error) {
         dispatch(getTrainersSuccess(data));
+        return data;
       } else {
         dispatch(getTrainersError(message));
-        dispatch(handleDisplayToast(true));
         dispatch(setContentToast({ message, state: 'fail' }));
+        dispatch(handleDisplayToast(true));
       }
     } catch (error) {
       dispatch(getTrainersError(error));
-      dispatch(handleDisplayToast(true));
       dispatch(setContentToast({ message: error.message, state: 'fail' }));
+      dispatch(handleDisplayToast(true));
     }
   };
 };
 
-export const addTrainer = (trainer, history) => {
+export const addTrainer = (trainer) => {
   return async (dispatch) => {
     dispatch(addTrainerPending());
     try {
@@ -60,19 +61,19 @@ export const addTrainer = (trainer, history) => {
 
       const { data, message, error } = await response.json();
       if (!error) {
-        history.push('/user/admin/trainers');
         dispatch(addTrainerSuccess(data));
-        dispatch(handleDisplayToast(true));
         dispatch(setContentToast({ message, state: 'success' }));
+        dispatch(handleDisplayToast(true));
+        dispatch(setRedirect());
       } else {
         dispatch(addTrainerError(message));
-        dispatch(handleDisplayToast(true));
         dispatch(setContentToast({ message, state: 'fail' }));
+        dispatch(handleDisplayToast(true));
       }
     } catch (error) {
       dispatch(addTrainerError(error));
-      dispatch(handleDisplayToast(true));
       dispatch(setContentToast({ message: error.message, state: 'fail' }));
+      dispatch(handleDisplayToast(true));
     }
   };
 };
@@ -92,19 +93,19 @@ export const updTrainer = (id, updatedTrainer) => {
       const { data, message, error } = await response.json();
       if (!error) {
         dispatch(editTrainerSuccess(data));
-        dispatch(handleDisplayToast(true));
         dispatch(setContentToast({ message, state: 'success' }));
+        dispatch(handleDisplayToast(true));
         dispatch(setRedirect());
         return data;
       } else {
         dispatch(editTrainerError(message));
-        dispatch(handleDisplayToast(true));
         dispatch(setContentToast({ message, state: 'fail' }));
+        dispatch(handleDisplayToast(true));
       }
     } catch (error) {
       dispatch(editTrainerError(error));
-      dispatch(handleDisplayToast(true));
       dispatch(setContentToast({ message: error.message, state: 'fail' }));
+      dispatch(handleDisplayToast(true));
     }
   };
 };
@@ -123,18 +124,18 @@ export const deleteTrainer = (id) => {
       const { data, message, error } = await response.json();
       if (!error) {
         dispatch(deleteTrainerSuccess(data));
-        dispatch(handleDisplayToast(true));
-        dispatch(setContentToast({ message, state: 'success' }));
         dispatch(getTrainers());
+        dispatch(setContentToast({ message, state: 'success' }));
+        dispatch(handleDisplayToast(true));
       } else {
         dispatch(deleteTrainerError(message));
-        dispatch(handleDisplayToast(true));
         dispatch(setContentToast({ message, state: 'fail' }));
+        dispatch(handleDisplayToast(true));
       }
     } catch (error) {
       dispatch(deleteTrainerError(error));
-      dispatch(handleDisplayToast(true));
       dispatch(setContentToast({ message: error.message, state: 'fail' }));
+      dispatch(handleDisplayToast(true));
     }
   };
 };


### PR DESCRIPTION
When you create or edit a trainer, should return to the trainers list.
When refresh the page in edit form, data should show.
When delete a trainer, should show the toast response.