### PR TITLE
BaSP-MR-234: Restructure input shared component error message

### DIFF
--- a/src/Components/Auth/Login/index.jsx
+++ b/src/Components/Auth/Login/index.jsx
@@ -67,11 +67,9 @@ function Login() {
             placeholder="Email"
             name="email"
             register={register}
+            error={errors.email?.message}
           />
         </div>
-        <span className={styles.errorMessage}>
-          {errors && errors.email?.message ? errors.email.message : '\u00A0'}
-        </span>
         <div className={styles.containerPassword}>
           <div className={styles.inputContainerPassword}>
             <Input
@@ -80,6 +78,7 @@ function Login() {
               name="password"
               placeholder="Password"
               register={register}
+              error={errors.password?.message}
             />
           </div>
           <div className={styles.buttonVisibilityPassword}>
@@ -91,9 +90,6 @@ function Login() {
             />
           </div>
         </div>
-        <span className={styles.errorMessage}>
-          {errors && errors.password?.message ? errors.password.message : '\u00A0'}
-        </span>
         <div>
           <Link to="/auth/forgotPassword">
             <a href="#">Have you forgotten your password?</a>

--- a/src/Components/Auth/Login/login.module.css
+++ b/src/Components/Auth/Login/login.module.css
@@ -73,12 +73,6 @@
   cursor: pointer;
 }
 
-.errorMessage {
-  padding: 10px;
-  color: red;
-  font-size: 0.8rem;
-}
-
 .buttonContainer {
   display: flex;
 }

--- a/src/Components/Auth/SignUp/index.jsx
+++ b/src/Components/Auth/SignUp/index.jsx
@@ -113,12 +113,8 @@ function SignUp() {
                     type={inputData.type === 'password' && viewPassword ? 'text' : inputData.type}
                     name={inputData.name}
                     register={register}
+                    error={errors[inputData.name]?.message}
                   />
-                  <div className={styles.errorMessage}>
-                    {errors && errors[inputData.name]?.message
-                      ? errors[inputData.name]?.message
-                      : '\u00A0'}
-                  </div>
                 </div>
                 {inputData.type === 'password' && (
                   <div className={styles.btnVisibilityPassword}>

--- a/src/Components/Auth/SignUp/signup.module.css
+++ b/src/Components/Auth/SignUp/signup.module.css
@@ -48,12 +48,6 @@
   cursor: pointer;
 }
 
-.errorMessage {
-  padding: 10px;
-  color: red;
-  font-size: 0.8rem;
-}
-
 .header h2 {
   margin: 0;
   align-self: center;

--- a/src/Components/Shared/Inputs/index.jsx
+++ b/src/Components/Shared/Inputs/index.jsx
@@ -27,7 +27,7 @@ export function Input({
         {...(register && { ...register(name) })}
         disabled={disabled || false}
       />
-      {error && <p className={styles.error}>{error}</p>}
+      <div className={styles.error}>{error ? error : '\u00A0'}</div>
     </>
   );
 }

--- a/src/Components/Shared/Inputs/index.jsx
+++ b/src/Components/Shared/Inputs/index.jsx
@@ -27,7 +27,7 @@ export function Input({
         {...(register && { ...register(name) })}
         disabled={disabled || false}
       />
-      <div className={styles.error}>{error ? error : '\u00A0'}</div>
+      <span className={styles.error}>{error ? error : '\u00A0'}</span>
     </>
   );
 }
@@ -47,7 +47,7 @@ export function Textarea({ labelText, rows, cols, name, placeholder, blur, regis
         onBlur={blur && blur}
         {...(register && { ...register(name) })}
       ></textarea>
-      {error && <p className={styles.error}>{error}</p>}
+      <span className={styles.error}>{error ? error : '\u00A0'}</span>
     </>
   );
 }

--- a/src/Components/Shared/Inputs/input.module.css
+++ b/src/Components/Shared/Inputs/input.module.css
@@ -27,4 +27,5 @@
 .error {
   color: red;
   font-size: 0.8rem;
+  margin-top: 10px;
 }


### PR DESCRIPTION
Added a wrapper to the error message in the shared input component so that when an error message appears it doesn't move the inputs
Before:
![image](https://github.com/BaSP-m2023/baru-megarocket-app/assets/127548159/63ff9bb2-c13a-48e9-b46d-a7daaefa5b3c)
After:
![image](https://github.com/BaSP-m2023/baru-megarocket-app/assets/127548159/4af5006b-75b3-4020-bfbe-c6231f2ca46c)
